### PR TITLE
Fix apex-jorje-lsp installer

### DIFF
--- a/installer/install-apex-jorje-lsp.cmd
+++ b/installer/install-apex-jorje-lsp.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-curl -o apex-jorje-lsp.jar "https://github.com/forcedotcom/salesforcedx-vscode/blob/develop/packages/salesforcedx-vscode-apex/out/apex-jorje-lsp.jar?raw=true"
+curl -o apex-jorje-lsp.jar -L "https://github.com/forcedotcom/salesforcedx-vscode/blob/develop/packages/salesforcedx-vscode-apex/out/apex-jorje-lsp.jar?raw=true"
 
 echo @echo off ^
 

--- a/installer/install-apex-jorje-lsp.sh
+++ b/installer/install-apex-jorje-lsp.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-curl -o apex-jorje-lsp.jar "https://github.com/forcedotcom/salesforcedx-vscode/blob/develop/packages/salesforcedx-vscode-apex/out/apex-jorje-lsp.jar?raw=true"
+curl -o apex-jorje-lsp.jar -L "https://github.com/forcedotcom/salesforcedx-vscode/blob/develop/packages/salesforcedx-vscode-apex/out/apex-jorje-lsp.jar?raw=true"
 
 cat <<EOF >apex-jorje-lsp
 


### PR DESCRIPTION
This command is redirected and as a result the installation fails.

command
`curl -o apex-jorje-lsp.jar "https://github.com/forcedotcom/salesforcedx-vscode/blob/develop/packages/salesforcedx-vscode-apex/out/apex-jorje-lsp.jar?raw=true"
`

response
`<html><body>You are being <a href="https://github.com/forcedotcom/salesforcedx-vscode/raw/develop/packages/salesforcedx-vscode-apex/out/apex-jorje-lsp.jar">redirected</a>.</body></html>
`

Adding the curl'-L' option will get the redirected content and the installation will succeed.
